### PR TITLE
Fix theming of https:// files - also fixes deprecated notice.

### DIFF
--- a/filefield_formatter.inc
+++ b/filefield_formatter.inc
@@ -117,7 +117,7 @@ function theme_filefield_file($file) {
 
   $path = $file['filepath'];
   // Check for remote filepath, if so return the raw path with protocol prefix
-  if (strpos($path, 'http://') === 0 || strpos($path, 'https://' === 0)) {
+  if (strpos($path, 'http://') === 0 || strpos($path, 'https://') === 0) {
     return l($file['filename'], $path);
   }
   else {


### PR DESCRIPTION
There's a typo in the check for filepaths starting with https:// This would ensure that https:// paths will never get formatted as intended, and also throws a deprecated notice because the needle evaluates to FALSE which is not a string:
Deprecated: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior in theme_filefield_file()